### PR TITLE
Fix references to SynTest Framework after the restructure

### DIFF
--- a/lib/runner/SolidityRunner.ts
+++ b/lib/runner/SolidityRunner.ts
@@ -1,7 +1,7 @@
 import {getLogger, getProperty} from "syntest-framework";
 import {Datapoint, Runner} from "syntest-framework";
 import {SuiteBuilder} from "syntest-framework";
-import {Individual} from "syntest-framework";
+import {TestCase} from "syntest-framework";
 import * as path from "path";
 
 const truffleUtils = require('../../plugins/resources/truffle.utils');
@@ -20,11 +20,11 @@ export class SolidityRunner extends Runner{
     }
 
 
-    async runTest(individual: Individual): Promise<Datapoint[]> {
+    async runTest(testCase: TestCase): Promise<Datapoint[]> {
         // TODO very stupid but we have to create actual files for truffle to run...
 
         const testPath = path.join(getProperty("temp_test_directory"), 'tempTest.js')
-        await this.suiteBuilder.writeTest(testPath, individual, "TODO")
+        await this.suiteBuilder.writeTest(testPath, testCase, "TODO")
 
         this.config.testDir = path.resolve(getProperty("temp_test_directory"))
         this.config.test_files = await truffleUtils.getTestFilePaths(this.config)

--- a/lib/search/sampling/SolidityRandomSampler.ts
+++ b/lib/search/sampling/SolidityRandomSampler.ts
@@ -1,5 +1,5 @@
-import {ObjectFunctionCall, prng, StringGene} from 'syntest-framework'
-import {Individual} from 'syntest-framework'
+import {ObjectFunctionCall, prng, String} from 'syntest-framework'
+import {TestCase} from 'syntest-framework'
 
 import {Bool} from 'syntest-framework'
 import {Fixed} from 'syntest-framework'
@@ -7,7 +7,7 @@ import {Ufixed} from 'syntest-framework'
 import {Int} from 'syntest-framework'
 import {Uint} from 'syntest-framework'
 import {Address} from 'syntest-framework'
-import {Gene} from "syntest-framework";
+import {Statement} from "syntest-framework";
 import {Constructor} from "syntest-framework";
 import {getProperty} from "syntest-framework";
 import {SoliditySampler} from "./SoliditySampler";
@@ -26,11 +26,11 @@ export class SolidityRandomSampler extends SoliditySampler {
         super(target)
     }
 
-    sampleIndividual (): Individual {
+    sampleIndividual (): TestCase {
         const action = prng.pickOne(this.target.getPossibleActions('function'))
         const root = this.sampleObjectFunctionCall(0, action.returnType)
 
-        return new Individual(root)
+        return new TestCase(root)
     }
 
     sampleConstructor (depth: number): Constructor {
@@ -39,7 +39,7 @@ export class SolidityRandomSampler extends SoliditySampler {
         return new Constructor(action.name, `${action.name}Object`, prng.uniqueId(), [])
     }
 
-    sampleArgument (depth: number, type: string): Gene {
+    sampleArgument (depth: number, type: string): Statement {
         // check depth to decide whether to pick a variable
         if (depth >= getProperty("max_depth")) {
             // TODO or take an already available variable
@@ -59,14 +59,14 @@ export class SolidityRandomSampler extends SoliditySampler {
         }
     }
 
-    sampleGene(depth: number, type: string, geneType= 'primitive'): Gene {
+    sampleGene(depth: number, type: string, geneType= 'primitive'): Statement {
         if (geneType === 'primitive') {
             if (type === 'bool') {
                 return Bool.getRandom()
             } else if (type === 'address') {
                 return Address.getRandom()
             } else if (type === 'string') {
-                return StringGene.getRandom()
+                return String.getRandom()
             } else if (type.includes('int')) {
                 if (type.includes('uint')) {
                     return Uint.getRandom()
@@ -83,7 +83,7 @@ export class SolidityRandomSampler extends SoliditySampler {
                     return Fixed.getRandom()
                 }
             } else if (type.includes('string')) {
-                return StringGene.getRandom()
+                return String.getRandom()
             } else if (type == "") {
                 throw new Error(`THERE U GO!`)
             }
@@ -99,7 +99,7 @@ export class SolidityRandomSampler extends SoliditySampler {
     sampleObjectFunctionCall (depth: number, type: string): ObjectFunctionCall {
         const action = prng.pickOne(this.target.getPossibleActions('function', type))
 
-        const args: Gene[] = []
+        const args: Statement[] = []
 
         for (const arg of action.args) {
             if (arg.type != "")

--- a/lib/search/sampling/SoliditySampler.ts
+++ b/lib/search/sampling/SoliditySampler.ts
@@ -1,6 +1,6 @@
 import {ObjectFunctionCall, Sampler} from 'syntest-framework'
 
-import {Gene} from "syntest-framework";
+import {Statement} from "syntest-framework";
 import {Constructor} from "syntest-framework";
 
 /**
@@ -12,5 +12,5 @@ export abstract class SoliditySampler extends Sampler {
 
     abstract sampleConstructor (depth: number): Constructor
     abstract sampleObjectFunctionCall (depth: number, type: string): ObjectFunctionCall
-    abstract sampleArgument (depth: number, type: string): Gene
+    abstract sampleArgument (depth: number, type: string): Statement
 }


### PR DESCRIPTION
This PR contains the changes necessary to make the tool compile again after the restructuring of SynTest Framework