### PR TITLE
Handling methods with different visibilities

### DIFF
--- a/src/search/objective/SolidityTarget.ts
+++ b/src/search/objective/SolidityTarget.ts
@@ -30,7 +30,8 @@ export class SolidityTarget extends Target {
     return this._functionCalls!.filter((f) => {
       return (
         (type === undefined || f.type === type) &&
-        (returnType === undefined || f.returnType === returnType)
+        (returnType === undefined || f.returnType === returnType) &&
+        (f.visibility === "public" || f.visibility === "external")
       );
     });
   }

--- a/src/testcase/sampling/SolidityRandomSampler.ts
+++ b/src/testcase/sampling/SolidityRandomSampler.ts
@@ -42,8 +42,8 @@ export class SolidityRandomSampler extends SoliditySampler {
 
   sampleMethodCall(root: ConstructorCall): ObjectFunctionCall {
     const actions = this.target
-      .getPossibleActions("function")
-      .filter((a) => a.visibility === "public" || a.visibility === "external");
+      .getPossibleActions("function");
+    
     const action = prng.pickOne(actions);
 
     const args: Statement[] = [];


### PR DESCRIPTION
Test cases for solidity smart contracts should only invoke methods with public/external visibility. Instead, private and internal methods should be covered/tested indirectly via the public/external methods. This commit handles methods with different visibility when creating and mutating test cases.

This commit fix the case where the generate tests trigger the error message "no call() for undefined". This error was due to invokation to private/internal methods.