### PR TITLE
Fix the coveage computation for requires related objectives

### DIFF
--- a/src/SolidityLauncher.ts
+++ b/src/SolidityLauncher.ts
@@ -548,7 +548,7 @@ async function testTarget(
     collectCoverageData(collector, archive, "branch");
     collectCoverageData(collector, archive, "statement");
     collectCoverageData(collector, archive, "function");
-    collectCoverageData(collector, archive, "probe");
+    collectProbeCoverageData(collector, archive);
 
     const numOfExceptions = archive
       .getObjectives()
@@ -716,20 +716,54 @@ function collectCoverageData(
         }
       }
       break;
-    case "probe":
-      {
-        collector.recordVariable(RuntimeVariable.COVERED_PROBES, covered.size);
-        collector.recordVariable(RuntimeVariable.TOTAL_PROBES, total.size);
+  }
+}
+function collectProbeCoverageData(
+  collector: StatisticsCollector<any>,
+  archive: Archive<any>
+): void {
+  let total = 0;
+  const covered = new Set();
 
-        if (total.size > 0.0) {
-          collector.recordVariable(
-            RuntimeVariable.PROBE_COVERAGE,
-            covered.size / total.size
-          );
-        } else {
-          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, 0);
-        }
-      }
-      break;
+  for (const key of archive.getObjectives()) {
+    const test = archive.getEncoding(key);
+    const result: ExecutionResult = test.getExecutionResult();
+    const contractName = key.getSubject().name.concat(".sol");
+
+    // filter by contract
+    const traces = result.getTraces().filter((element) => {
+      const paths = (element as any).contractPath.split("/");
+      return paths[paths.length - 1].includes(contractName);
+    });
+
+    const preTraces = traces.filter(
+      (element) => element.type.includes("probePre") && element.hits > 0
+    );
+    const postTraces = traces.filter((element) =>
+      element.type.includes("probePost")
+    );
+
+    total = postTraces.length * 2;
+
+    preTraces.forEach((trace) => {
+      postTraces
+        .filter((postTrace) => postTrace.line == trace.line)
+        .forEach((postTrace) => {
+          if (postTrace.hits > 0) covered.add(postTrace.line + "_true");
+          else covered.add(postTrace.line + "_false");
+        });
+    });
+  }
+
+  collector.recordVariable(RuntimeVariable.COVERED_PROBES, covered.size);
+  collector.recordVariable(RuntimeVariable.TOTAL_PROBES, total);
+
+  if (total > 0.0) {
+    collector.recordVariable(
+      RuntimeVariable.PROBE_COVERAGE,
+      covered.size / total
+    );
+  } else {
+    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, 0);
   }
 }


### PR DESCRIPTION
Fixing a bug I discovered running our benchmark. Now the coverage statistics for the requires statements work correctly