### PR TITLE
Repair the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ module.exports = {
 Next, you can run the following truffle command.
 
 ```bash
-$ truffle run syntest-solidity [options]
+$ truffle run @syntest/solidity [options]
 ```
 
 ## Documentation

--- a/docker/templates/truffle-config.js
+++ b/docker/templates/truffle-config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: ["syntest-solidity"],
+  plugins: ["@syntest/solidity"],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntest/solidity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SynTest Solidity is a tool for automatically generating test cases for the Solidity platform",
   "keywords": [
     "syntest",
@@ -20,6 +20,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "/dist",
+    "/src/**/*.js",
     "/api.js",
     "/NOTICE"
   ],

--- a/src/util/fileSystem.ts
+++ b/src/util/fileSystem.ts
@@ -65,7 +65,7 @@ export async function createTruffleConfig() {
     filepath,
     `module.exports = {
   test_directory: ".syntest/tests",
-  plugins: ["syntest-solidity"]
+  plugins: ["@syntest/solidity"]
 };`
   );
 }

--- a/truffle-plugin.json
+++ b/truffle-plugin.json
@@ -1,5 +1,5 @@
 {
   "commands": {
-    "syntest-solidity": "truffle.plugin.js"
+    "@syntest/solidity": "truffle.plugin.js"
   }
 }


### PR DESCRIPTION
truffle run syntest-solidity does not work since the package is renamed to @syntest/solidity
truffle run @syntest/solidity because our truffle-plugin.json file does not list that as a truffle plugin
syntest-solidity command does not work because .js files are not included in the package
