### PR TITLE
Change to @syntest/core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         run: npm install
         working-directory: syntest-solidity
       - name: Solidity - Link Local Framework
-        run: npm link @syntest/framework
+        run: npm link @syntest/core
         working-directory: syntest-solidity
 
       # Building

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To be able to make quick changes to the syntest-framework and then test it in th
 
 ```bash
 cd <PATH_TO_SYNTEST_FRAMEWORK>; npm link
-cd <PATH_TO_SYNTEST_SOLIDITY>; npm link @syntest/framework
+cd <PATH_TO_SYNTEST_SOLIDITY>; npm link @syntest/core
 ```
 
 This creates a symbolic link to the local syntest-framework instance in the node modules folder of syntest-solidity.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@solidity-parser/parser": "0.14.5",
-    "@syntest/core": "../syntest-framework",
+    "@syntest/core": "^0.2.0",
     "@truffle/config": "^1.2.44",
     "@truffle/provider": "^0.1.17",
     "bignumber.js": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@solidity-parser/parser": "0.14.5",
-    "@syntest/core": "^0.2.0",
+    "@syntest/core": "0.2.0",
     "@truffle/config": "^1.2.44",
     "@truffle/provider": "^0.1.17",
     "bignumber.js": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@solidity-parser/parser": "0.14.5",
-    "@syntest/framework": "^0.1.2",
+    "@syntest/core": "^0.2.0",
     "@truffle/config": "^1.2.44",
     "@truffle/provider": "^0.1.17",
     "bignumber.js": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -83,12 +83,12 @@
     "chai": "^4.3.3",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.1.0",
-    "mocha": "^8.3.1",
+    "mocha": "10.2.0",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.3.5"
+    "ts-node": "10.9.1",
+    "typescript": "4.9.4"
   },
   "engines": {
     "node": ">=10.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntest/solidity",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "SynTest Solidity is a tool for automatically generating test cases for the Solidity platform",
   "keywords": [
     "syntest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntest/solidity",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "description": "SynTest Solidity is a tool for automatically generating test cases for the Solidity platform",
   "keywords": [
     "syntest",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@solidity-parser/parser": "0.14.5",
-    "@syntest/core": "^0.2.0",
+    "@syntest/core": "../syntest-framework",
     "@truffle/config": "^1.2.44",
     "@truffle/provider": "^0.1.17",
     "bignumber.js": "9.0.1",

--- a/src/SolidityLauncher.ts
+++ b/src/SolidityLauncher.ts
@@ -51,7 +51,7 @@ import {
   getSeed,
   clearDirectory,
   createTempDirectoryStructure,
-  Target
+  Target,
 } from "@syntest/core";
 
 import * as path from "path";
@@ -66,7 +66,7 @@ import {
   createTruffleConfig,
   getTestFilePaths,
   loadLibrary,
-  setupTempFolders
+  setupTempFolders,
 } from "./util/fileSystem";
 
 import Messages from "./ui/Messages";
@@ -145,7 +145,10 @@ export class SolidityLauncher {
         required: true,
       },
     }; // TODO
-    setupOptions(this._program, <Record<string, unknown>[]><unknown>additionalOptions);
+    setupOptions(
+      this._program,
+      <Record<string, unknown>[]>(<unknown>additionalOptions)
+    );
 
     const index = process.argv.indexOf(
       process.argv.find((a) => a.includes(this._program))
@@ -192,16 +195,16 @@ export class SolidityLauncher {
 
     this.config.compilers = {
       solc: {
-        version: Properties['solc_compiler_version'],
+        version: Properties["solc_compiler_version"],
         parser: "solcjs",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 2
-          }
-        }
-      }
-    }
+            runs: 2,
+          },
+        },
+      },
+    };
     this.truffle = loadLibrary(this.config);
     this.api = new API(myConfig);
 
@@ -236,14 +239,13 @@ export class SolidityLauncher {
 
     getUserInterface().report("header", ["GENERAL INFO"]);
 
-    getUserInterface().report("property-set", [
-      "Network Info",
-      <string><unknown>[
+    getUserInterface().report("property-set", ["Network Info", <string>(<
+        unknown
+      >[
         ["id", this.config.network],
         ["port", this.config.networks[this.config.network].network_id],
         ["network", this.config.networks[this.config.network].port],
-      ],
-    ]);
+      ])]);
 
     getUserInterface().report("header", ["TARGETS"]);
 
@@ -283,25 +285,19 @@ export class SolidityLauncher {
     getUserInterface().report("header", ["CONFIGURATION"]);
 
     getUserInterface().report("single-property", ["Seed", getSeed()]);
-    getUserInterface().report("property-set", [
-      "Budgets",
-      <string><unknown>[
+    getUserInterface().report("property-set", ["Budgets", <string>(<unknown>[
         ["Iteration Budget", `${Properties.iteration_budget} iterations`],
         ["Evaluation Budget", `${Properties.evaluation_budget} evaluations`],
         ["Search Time Budget", `${Properties.search_time} seconds`],
         ["Total Time Budget", `${Properties.total_time} seconds`],
-      ],
-    ]);
-    getUserInterface().report("property-set", [
-      "Algorithm",
-      <string><unknown>[
+      ])]);
+    getUserInterface().report("property-set", ["Algorithm", <string>(<unknown>[
         ["Algorithm", Properties.algorithm],
         ["Population Size", Properties.population_size],
-      ],
-    ]);
+      ])]);
     getUserInterface().report("property-set", [
       "Variation Probabilities",
-      <string><unknown>[
+      <string>(<unknown>[
         ["Resampling", Properties.resample_gene_probability],
         ["Delta mutation", Properties.delta_mutation_probability],
         [
@@ -309,18 +305,15 @@ export class SolidityLauncher {
           Properties.sample_existing_value_probability,
         ],
         ["Crossover", Properties.crossover_probability],
-      ],
+      ]),
     ]);
 
-    getUserInterface().report("property-set", [
-      "Sampling",
-      <string><unknown>[
+    getUserInterface().report("property-set", ["Sampling", <string>(<unknown>[
         ["Max Depth", Properties.max_depth],
         ["Explore Illegal Values", Properties.explore_illegal_values],
         ["Sample Function Result as Argument", Properties.sample_func_as_arg],
         ["Crossover", Properties.crossover_probability],
-      ],
-    ]);
+      ])]);
 
     return targetPool;
   }

--- a/src/SolidityLauncher.ts
+++ b/src/SolidityLauncher.ts
@@ -51,7 +51,8 @@ import {
   getSeed,
   clearDirectory,
   createTempDirectoryStructure,
-} from "@syntest/framework";
+  Target
+} from "@syntest/core";
 
 import * as path from "path";
 import TruffleConfig = require("@truffle/config");
@@ -87,7 +88,6 @@ import {
   collectInitialVariables,
   collectStatistics,
 } from "./util/collection";
-import { Target } from "@syntest/framework";
 
 const pkg = require("../package.json");
 const Web3 = require("web3");

--- a/src/SolidityLauncher.ts
+++ b/src/SolidityLauncher.ts
@@ -145,7 +145,7 @@ export class SolidityLauncher {
         required: true,
       },
     }; // TODO
-    setupOptions(this._program, additionalOptions);
+    setupOptions(this._program, <Record<string, unknown>[]><unknown>additionalOptions);
 
     const index = process.argv.indexOf(
       process.argv.find((a) => a.includes(this._program))
@@ -238,7 +238,7 @@ export class SolidityLauncher {
 
     getUserInterface().report("property-set", [
       "Network Info",
-      [
+      <string><unknown>[
         ["id", this.config.network],
         ["port", this.config.networks[this.config.network].network_id],
         ["network", this.config.networks[this.config.network].port],
@@ -285,7 +285,7 @@ export class SolidityLauncher {
     getUserInterface().report("single-property", ["Seed", getSeed()]);
     getUserInterface().report("property-set", [
       "Budgets",
-      [
+      <string><unknown>[
         ["Iteration Budget", `${Properties.iteration_budget} iterations`],
         ["Evaluation Budget", `${Properties.evaluation_budget} evaluations`],
         ["Search Time Budget", `${Properties.search_time} seconds`],
@@ -294,14 +294,14 @@ export class SolidityLauncher {
     ]);
     getUserInterface().report("property-set", [
       "Algorithm",
-      [
+      <string><unknown>[
         ["Algorithm", Properties.algorithm],
         ["Population Size", Properties.population_size],
       ],
     ]);
     getUserInterface().report("property-set", [
       "Variation Probabilities",
-      [
+      <string><unknown>[
         ["Resampling", Properties.resample_gene_probability],
         ["Delta mutation", Properties.delta_mutation_probability],
         [
@@ -314,7 +314,7 @@ export class SolidityLauncher {
 
     getUserInterface().report("property-set", [
       "Sampling",
-      [
+      <string><unknown>[
         ["Max Depth", Properties.max_depth],
         ["Explore Illegal Values", Properties.explore_illegal_values],
         ["Sample Function Result as Argument", Properties.sample_func_as_arg],

--- a/src/analysis/static/SolidityTarget.ts
+++ b/src/analysis/static/SolidityTarget.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { CFG, Target } from "@syntest/framework";
+import { CFG, Target } from "@syntest/core";
 
 import { SolidityTargetPool } from "./SolidityTargetPool";
 import * as path from "path";

--- a/src/analysis/static/SolidityTargetPool.ts
+++ b/src/analysis/static/SolidityTargetPool.ts
@@ -23,12 +23,10 @@ import { TargetMapGenerator } from "./map/TargetMapGenerator";
 import { SolidityCFGFactory } from "../../graph/SolidityCFGFactory";
 import { ContractMetadata } from "./map/ContractMetadata";
 import { ContractFunction } from "./map/ContractFunction";
-import { CFG, Properties } from "@syntest/framework";
+import { CFG, Properties, TargetPool, Target } from "@syntest/core";
 import { ImportVisitor } from "./dependency/ImportVisitor";
 import * as fs from "fs";
 import { LibraryVisitor } from "./dependency/LibraryVisitor";
-import { TargetPool } from "@syntest/framework";
-import { Target } from "@syntest/framework";
 const SolidityParser = require("@solidity-parser/parser");
 const { outputFileSync, copySync } = require("fs-extra");
 const Instrumenter = require("../../../src/instrumentation/instrumenter"); // Local version

--- a/src/analysis/static/map/ContractMetadata.ts
+++ b/src/analysis/static/map/ContractMetadata.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { TargetMetaData } from "@syntest/framework";
+import { TargetMetaData } from "@syntest/core";
 
 /**
  * Interface for Solidity contract metadata.

--- a/src/analysis/static/map/ContractVisitor.ts
+++ b/src/analysis/static/map/ContractVisitor.ts
@@ -209,7 +209,7 @@ export class ContractVisitor implements SolidityVisitor {
         break;
       }
       case "Mapping": {
-        if (type.keyType.type === 'ElementaryTypeName') {
+        if (type.keyType.type === "ElementaryTypeName") {
           paramType = `Map<${type.keyType.name},${this.resolveTypes(
             type.valueType
           )}>`;

--- a/src/api.js
+++ b/src/api.js
@@ -156,7 +156,14 @@ class API {
       try {
         // the string replacement is necessary because the istanbul reporter expects contractPath...
         // should be fixed by a custom made reporter specific to this project
-        this.coverage.generate(JSON.parse(JSON.stringify(this.instrumenter.instrumentationData).replaceAll('path', 'contractPath')));
+        this.coverage.generate(
+          JSON.parse(
+            JSON.stringify(this.instrumenter.instrumentationData).replaceAll(
+              "path",
+              "contractPath"
+            )
+          )
+        );
 
         const mapping = this.makeKeysRelative(this.coverage.data, this.cwd);
         this.saveCoverage(mapping);

--- a/src/criterion/RequireObjectiveFunction.ts
+++ b/src/criterion/RequireObjectiveFunction.ts
@@ -24,7 +24,7 @@ import {
   NodeType,
   ProbeObjectiveFunction,
   SearchSubject,
-} from "@syntest/framework";
+} from "@syntest/core";
 
 export class RequireObjectiveFunction<
   T extends Encoding

--- a/src/graph/SolidityCFGFactory.ts
+++ b/src/graph/SolidityCFGFactory.ts
@@ -27,7 +27,7 @@ import {
   CFGFactory,
   Properties,
   NodeType,
-} from "@syntest/framework";
+} from "@syntest/core";
 
 import {
   ExternalVisibility,

--- a/src/search/SolidityExecutionResult.ts
+++ b/src/search/SolidityExecutionResult.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { ExecutionResult, Datapoint } from "@syntest/framework";
+import { ExecutionResult, Datapoint } from "@syntest/core";
 
 export enum SolidityExecutionStatus {
   PASSED,

--- a/src/search/SoliditySubject.ts
+++ b/src/search/SoliditySubject.ts
@@ -25,7 +25,7 @@ import {
   NodeType,
   ObjectiveFunction,
   SearchSubject,
-} from "@syntest/framework";
+} from "@syntest/core";
 
 import { RequireObjectiveFunction } from "../criterion/RequireObjectiveFunction";
 import { ExternalVisibility } from "../analysis/static/map/ContractFunction";

--- a/src/search/operators/crossover/SolidityTreeCrossover.ts
+++ b/src/search/operators/crossover/SolidityTreeCrossover.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Crossover, Properties } from "@syntest/framework";
+import { prng, Crossover, Properties } from "@syntest/core";
 
 import { SolidityTestCase } from "../../../testcase/SolidityTestCase";
 import { ConstructorCall } from "../../../testcase/statements/action/ConstructorCall";

--- a/src/seeding/constant/ConstantPool.ts
+++ b/src/seeding/constant/ConstantPool.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng } from "@syntest/framework";
+import { prng } from "@syntest/core";
 
 /**
  * A pool with constants extracted from the subject under test.

--- a/src/testbuilding/SolidityDecoder.ts
+++ b/src/testbuilding/SolidityDecoder.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Properties, Decoder } from "@syntest/framework";
+import { Properties, Decoder } from "@syntest/core";
 
 import * as path from "path";
 import * as web3_utils from "web3-utils";
@@ -28,7 +28,7 @@ import { ObjectFunctionCall } from "../testcase/statements/action/ObjectFunction
 import { SolidityTestCase } from "../testcase/SolidityTestCase";
 import { Statement } from "../testcase/statements/Statement";
 import { PrimitiveStatement } from "../testcase/statements/primitive/PrimitiveStatement";
-import { Target } from "@syntest/framework";
+import { Target } from "@syntest/core";
 
 /**
  * @author Dimitri Stallenberg

--- a/src/testbuilding/SoliditySuiteBuilder.ts
+++ b/src/testbuilding/SoliditySuiteBuilder.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Properties, Archive, getUserInterface } from "@syntest/framework";
+import { Properties, Archive, getUserInterface } from "@syntest/core";
 
 import {
   readdirSync,

--- a/src/testcase/SolidityTestCase.ts
+++ b/src/testcase/SolidityTestCase.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { getUserInterface, Encoding, Decoder } from "@syntest/framework";
+import { getUserInterface, Encoding, Decoder } from "@syntest/core";
 import { ConstructorCall } from "./statements/action/ConstructorCall";
 import { SoliditySampler } from "./sampling/SoliditySampler";
 

--- a/src/testcase/execution/SolidityRunner.ts
+++ b/src/testcase/execution/SolidityRunner.ts
@@ -21,7 +21,7 @@ import {
   Properties,
   getUserInterface,
   EncodingRunner,
-} from "@syntest/framework";
+} from "@syntest/core";
 
 import * as path from "path";
 import {

--- a/src/testcase/sampling/SolidityRandomSampler.ts
+++ b/src/testcase/sampling/SolidityRandomSampler.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 
 import { SoliditySampler } from "./SoliditySampler";
 import { AddressStatement } from "../statements/primitive/AddressStatement";

--- a/src/testcase/sampling/SoliditySampler.ts
+++ b/src/testcase/sampling/SoliditySampler.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { SearchSubject, EncodingSampler } from "@syntest/framework";
+import { SearchSubject, EncodingSampler } from "@syntest/core";
 import { Parameter } from "../../analysis/static/parsing/Parameter";
 
 import { SolidityTestCase } from "../SolidityTestCase";

--- a/src/testcase/statements/RootStatement.ts
+++ b/src/testcase/statements/RootStatement.ts
@@ -17,8 +17,8 @@
  */
 
 import { Statement } from "./Statement";
-import { EncodingSampler } from "@syntest/framework/dist/search/EncodingSampler";
-import { Encoding } from "@syntest/framework/dist/search/Encoding";
+import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
+import { Encoding } from "@syntest/core/dist/search/Encoding";
 import { ActionStatement } from "./action/ActionStatement";
 import { Parameter } from "../../analysis/static/parsing/Parameter";
 

--- a/src/testcase/statements/RootStatement.ts
+++ b/src/testcase/statements/RootStatement.ts
@@ -17,8 +17,7 @@
  */
 
 import { Statement } from "./Statement";
-import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
-import { Encoding } from "@syntest/core/dist/search/Encoding";
+import { Encoding, EncodingSampler } from "@syntest/core";
 import { ActionStatement } from "./action/ActionStatement";
 import { Parameter } from "../../analysis/static/parsing/Parameter";
 

--- a/src/testcase/statements/Statement.ts
+++ b/src/testcase/statements/Statement.ts
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
-import { prng } from "@syntest/core/dist/util/prng";
-import { Encoding } from "@syntest/core/dist/search/Encoding";
+import { prng, EncodingSampler, Encoding } from "@syntest/core";
 import { Parameter } from "../../analysis/static/parsing/Parameter";
 
 /**

--- a/src/testcase/statements/Statement.ts
+++ b/src/testcase/statements/Statement.ts
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-import { EncodingSampler } from "@syntest/framework/dist/search/EncodingSampler";
-import { prng } from "@syntest/framework/dist/util/prng";
-import { Encoding } from "@syntest/framework/dist/search/Encoding";
+import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
+import { prng } from "@syntest/core/dist/util/prng";
+import { Encoding } from "@syntest/core/dist/search/Encoding";
 import { Parameter } from "../../analysis/static/parsing/Parameter";
 
 /**

--- a/src/testcase/statements/action/ActionStatement.ts
+++ b/src/testcase/statements/action/ActionStatement.ts
@@ -17,8 +17,8 @@
  */
 
 import { Statement } from "../Statement";
-import { EncodingSampler } from "@syntest/framework";
-import { Encoding } from "@syntest/framework";
+import { EncodingSampler } from "@syntest/core";
+import { Encoding } from "@syntest/core";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";
 
 /**

--- a/src/testcase/statements/action/ConstructorCall.ts
+++ b/src/testcase/statements/action/ConstructorCall.ts
@@ -17,7 +17,7 @@
  */
 
 import { AddressStatement } from "../primitive/AddressStatement";
-import { prng } from "@syntest/framework";
+import { prng } from "@syntest/core";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { ActionStatement } from "./ActionStatement";
 import { Statement } from "../Statement";

--- a/src/testcase/statements/action/FunctionCall.ts
+++ b/src/testcase/statements/action/FunctionCall.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { ActionStatement } from "./ActionStatement";
 import { Statement } from "../Statement";

--- a/src/testcase/statements/action/ObjectFunctionCall.ts
+++ b/src/testcase/statements/action/ObjectFunctionCall.ts
@@ -19,7 +19,7 @@
 import { ConstructorCall } from "./ConstructorCall";
 import { AddressStatement } from "../primitive/AddressStatement";
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { ActionStatement } from "./ActionStatement";
 import { Statement } from "../Statement";

--- a/src/testcase/statements/primitive/AddressStatement.ts
+++ b/src/testcase/statements/primitive/AddressStatement.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Properties, prng } from "@syntest/framework";
+import { Properties, prng } from "@syntest/core";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";
 import { ConstantPool } from "../../../seeding/constant/ConstantPool";
 import { SoliditySampler } from "../../sampling/SoliditySampler";

--- a/src/testcase/statements/primitive/BoolStatement.ts
+++ b/src/testcase/statements/primitive/BoolStatement.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { PrimitiveStatement } from "./PrimitiveStatement";

--- a/src/testcase/statements/primitive/ByteStatement.ts
+++ b/src/testcase/statements/primitive/ByteStatement.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Properties, prng } from "@syntest/framework";
+import { Properties, prng } from "@syntest/core";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { PrimitiveStatement } from "./PrimitiveStatement";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";

--- a/src/testcase/statements/primitive/NumericStatement.ts
+++ b/src/testcase/statements/primitive/NumericStatement.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 
 import BigNumber from "bignumber.js";
 import { ConstantPool } from "../../../seeding/constant/ConstantPool";

--- a/src/testcase/statements/primitive/PrimitiveStatement.ts
+++ b/src/testcase/statements/primitive/PrimitiveStatement.ts
@@ -17,7 +17,7 @@
  */
 
 import { Statement } from "../Statement";
-import { EncodingSampler } from "@syntest/framework/dist/search/EncodingSampler";
+import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";
 
 /**

--- a/src/testcase/statements/primitive/PrimitiveStatement.ts
+++ b/src/testcase/statements/primitive/PrimitiveStatement.ts
@@ -17,7 +17,7 @@
  */
 
 import { Statement } from "../Statement";
-import { EncodingSampler } from "@syntest/core/dist/search/EncodingSampler";
+import { EncodingSampler } from "@syntest/core";
 import { Parameter } from "../../../analysis/static/parsing/Parameter";
 
 /**

--- a/src/testcase/statements/primitive/StringStatement.ts
+++ b/src/testcase/statements/primitive/StringStatement.ts
@@ -75,7 +75,7 @@ export class StringStatement extends PrimitiveStatement<string> {
 
   addMutation(): StringStatement {
     const position = prng.nextInt(0, this.value.length - 1);
-    const addedChar = prng.pickOne(this.alphabet.split(''));
+    const addedChar = prng.pickOne(this.alphabet.split(""));
 
     let newValue = "";
 
@@ -120,7 +120,7 @@ export class StringStatement extends PrimitiveStatement<string> {
 
   replaceMutation(): StringStatement {
     const position = prng.nextInt(0, this.value.length - 1);
-    const newChar = prng.pickOne(this.alphabet.split(''));
+    const newChar = prng.pickOne(this.alphabet.split(""));
 
     let newValue = "";
 
@@ -195,7 +195,7 @@ export class StringStatement extends PrimitiveStatement<string> {
     let value = "";
 
     for (let i = 0; i < valueLength; i++) {
-      value += prng.pickOne(alphabet.split(''));
+      value += prng.pickOne(alphabet.split(""));
     }
 
     return new StringStatement(

--- a/src/testcase/statements/primitive/StringStatement.ts
+++ b/src/testcase/statements/primitive/StringStatement.ts
@@ -75,7 +75,7 @@ export class StringStatement extends PrimitiveStatement<string> {
 
   addMutation(): StringStatement {
     const position = prng.nextInt(0, this.value.length - 1);
-    const addedChar = prng.pickOne(this.alphabet);
+    const addedChar = prng.pickOne(this.alphabet.split(''));
 
     let newValue = "";
 
@@ -120,7 +120,7 @@ export class StringStatement extends PrimitiveStatement<string> {
 
   replaceMutation(): StringStatement {
     const position = prng.nextInt(0, this.value.length - 1);
-    const newChar = prng.pickOne(this.alphabet);
+    const newChar = prng.pickOne(this.alphabet.split(''));
 
     let newValue = "";
 
@@ -195,7 +195,7 @@ export class StringStatement extends PrimitiveStatement<string> {
     let value = "";
 
     for (let i = 0; i < valueLength; i++) {
-      value += prng.pickOne(alphabet);
+      value += prng.pickOne(alphabet.split(''));
     }
 
     return new StringStatement(

--- a/src/testcase/statements/primitive/StringStatement.ts
+++ b/src/testcase/statements/primitive/StringStatement.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { prng, Properties } from "@syntest/framework";
+import { prng, Properties } from "@syntest/core";
 import { ConstantPool } from "../../../seeding/constant/ConstantPool";
 import { SoliditySampler } from "../../sampling/SoliditySampler";
 import { PrimitiveStatement } from "./PrimitiveStatement";

--- a/src/ui/SolidityCommandLineInterface.ts
+++ b/src/ui/SolidityCommandLineInterface.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { CommandLineInterface, yargs } from "@syntest/framework";
+import { CommandLineInterface, yargs } from "@syntest/core";
 
 import Messages from "./Messages";
 

--- a/src/ui/SolidityMonitorCommandLineInterface.ts
+++ b/src/ui/SolidityMonitorCommandLineInterface.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { MonitorCommandLineInterface, yargs } from "@syntest/framework";
+import { MonitorCommandLineInterface, yargs } from "@syntest/core";
 import Messages from "./Messages";
 
 const clear = require("clear");

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -29,7 +29,7 @@ import {
   SearchTimeBudget,
   StatisticsCollector,
   TotalTimeBudget,
-} from "@syntest/framework";
+} from "@syntest/core";
 import { SoliditySubject } from "../search/SoliditySubject";
 
 export function collectInitialVariables(
@@ -37,7 +37,7 @@ export function collectInitialVariables(
   currentSubject: SoliditySubject,
   targetPath: string
 ) {
-  collector.recordVariable(RuntimeVariable.VERSION, 1);
+  collector.recordVariable(RuntimeVariable.VERSION, `${1}`);
   collector.recordVariable(
     RuntimeVariable.CONFIGURATION,
     Properties.configuration
@@ -46,16 +46,16 @@ export function collectInitialVariables(
   collector.recordVariable(RuntimeVariable.SUBJECT, path.basename(targetPath));
   collector.recordVariable(
     RuntimeVariable.PROBE_ENABLED,
-    Properties.probe_objective
+    `${Properties.probe_objective}`
   );
   collector.recordVariable(
     RuntimeVariable.CONSTANT_POOL_ENABLED,
-    Properties.constant_pool
+    `${Properties.constant_pool}`
   );
   collector.recordVariable(RuntimeVariable.ALGORITHM, Properties.algorithm);
   collector.recordVariable(
     RuntimeVariable.TOTAL_OBJECTIVES,
-    currentSubject.getObjectives().length
+    `${currentSubject.getObjectives().length}`
   );
 }
 
@@ -70,27 +70,27 @@ export function collectStatistics(
 ) {
   collector.recordVariable(
     RuntimeVariable.COVERED_OBJECTIVES,
-    archive.getObjectives().length
+    `${archive.getObjectives().length}`
   );
   collector.recordVariable(
     RuntimeVariable.INITIALIZATION_TIME,
-    totalTimeBudget.getUsedBudget() - searchBudget.getUsedBudget()
+    `${totalTimeBudget.getUsedBudget() - searchBudget.getUsedBudget()}`
   );
   collector.recordVariable(
     RuntimeVariable.SEARCH_TIME,
-    searchBudget.getUsedBudget()
+    `${searchBudget.getUsedBudget()}`
   );
   collector.recordVariable(
     RuntimeVariable.TOTAL_TIME,
-    totalTimeBudget.getUsedBudget()
+    `${totalTimeBudget.getUsedBudget()}`
   );
   collector.recordVariable(
     RuntimeVariable.ITERATIONS,
-    iterationBudget.getUsedBudget()
+    `${iterationBudget.getUsedBudget()}`
   );
   collector.recordVariable(
     RuntimeVariable.EVALUATIONS,
-    evaluationBudget.getUsedBudget()
+    `${evaluationBudget.getUsedBudget()}`
   );
 
   const numOfExceptions = archive
@@ -99,12 +99,12 @@ export function collectStatistics(
       (objective) => objective instanceof ExceptionObjectiveFunction
     ).length;
 
-  collector.recordVariable(RuntimeVariable.COVERED_EXCEPTIONS, numOfExceptions);
+  collector.recordVariable(RuntimeVariable.COVERED_EXCEPTIONS, `${numOfExceptions}`);
 
   collector.recordVariable(
     RuntimeVariable.COVERAGE,
-    (archive.getObjectives().length - numOfExceptions) /
-      currentSubject.getObjectives().length
+    `${(archive.getObjectives().length - numOfExceptions) /
+      currentSubject.getObjectives().length}`
   );
 }
 
@@ -146,32 +146,32 @@ export function collectCoverageData(
       {
         collector.recordVariable(
           RuntimeVariable.COVERED_BRANCHES,
-          covered.size
+          `${covered.size}`
         );
-        collector.recordVariable(RuntimeVariable.TOTAL_BRANCHES, total.size);
+        collector.recordVariable(RuntimeVariable.TOTAL_BRANCHES, `${total.size}`);
 
         if (total.size > 0.0) {
           collector.recordVariable(
             RuntimeVariable.BRANCH_COVERAGE,
-            covered.size / total.size
+            `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.BRANCH_COVERAGE, 0);
+          collector.recordVariable(RuntimeVariable.BRANCH_COVERAGE, `${0}`);
         }
       }
       break;
     case "statement":
       {
-        collector.recordVariable(RuntimeVariable.COVERED_LINES, covered.size);
-        collector.recordVariable(RuntimeVariable.TOTAL_LINES, total.size);
+        collector.recordVariable(RuntimeVariable.COVERED_LINES, `${covered.size}`);
+        collector.recordVariable(RuntimeVariable.TOTAL_LINES, `${total.size}`);
 
         if (total.size > 0.0) {
           collector.recordVariable(
             RuntimeVariable.LINE_COVERAGE,
-            covered.size / total.size
+            `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, 0);
+          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, `${0}`);
         }
       }
       break;
@@ -179,32 +179,32 @@ export function collectCoverageData(
       {
         collector.recordVariable(
           RuntimeVariable.COVERED_FUNCTIONS,
-          covered.size
+          `${covered.size}`
         );
-        collector.recordVariable(RuntimeVariable.TOTAL_FUNCTIONS, total.size);
+        collector.recordVariable(RuntimeVariable.TOTAL_FUNCTIONS, `${total.size}`);
 
         if (total.size > 0.0) {
           collector.recordVariable(
             RuntimeVariable.FUNCTION_COVERAGE,
-            covered.size / total.size
+            `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, 0);
+          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, `${0}`);
         }
       }
       break;
     case "probe":
       {
-        collector.recordVariable(RuntimeVariable.COVERED_PROBES, covered.size);
-        collector.recordVariable(RuntimeVariable.TOTAL_PROBES, total.size);
+        collector.recordVariable(RuntimeVariable.COVERED_PROBES, `${covered.size}`);
+        collector.recordVariable(RuntimeVariable.TOTAL_PROBES, `${total.size}`);
 
         if (total.size > 0.0) {
           collector.recordVariable(
             RuntimeVariable.PROBE_COVERAGE,
-            covered.size / total.size
+            `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, 0);
+          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, `${0}`);
         }
       }
       break;
@@ -248,15 +248,15 @@ export function collectProbeCoverageData(
     });
   }
 
-  collector.recordVariable(RuntimeVariable.COVERED_PROBES, covered.size);
-  collector.recordVariable(RuntimeVariable.TOTAL_PROBES, total);
+  collector.recordVariable(RuntimeVariable.COVERED_PROBES, `${covered.size}`);
+  collector.recordVariable(RuntimeVariable.TOTAL_PROBES, `${total}`);
 
   if (total > 0.0) {
     collector.recordVariable(
       RuntimeVariable.PROBE_COVERAGE,
-      covered.size / total
+      `${covered.size / total}`
     );
   } else {
-    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, 0);
+    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, `${0}`);
   }
 }

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -99,12 +99,17 @@ export function collectStatistics(
       (objective) => objective instanceof ExceptionObjectiveFunction
     ).length;
 
-  collector.recordVariable(RuntimeVariable.COVERED_EXCEPTIONS, `${numOfExceptions}`);
+  collector.recordVariable(
+    RuntimeVariable.COVERED_EXCEPTIONS,
+    `${numOfExceptions}`
+  );
 
   collector.recordVariable(
     RuntimeVariable.COVERAGE,
-    `${(archive.getObjectives().length - numOfExceptions) /
-      currentSubject.getObjectives().length}`
+    `${
+      (archive.getObjectives().length - numOfExceptions) /
+      currentSubject.getObjectives().length
+    }`
   );
 }
 
@@ -148,7 +153,10 @@ export function collectCoverageData(
           RuntimeVariable.COVERED_BRANCHES,
           `${covered.size}`
         );
-        collector.recordVariable(RuntimeVariable.TOTAL_BRANCHES, `${total.size}`);
+        collector.recordVariable(
+          RuntimeVariable.TOTAL_BRANCHES,
+          `${total.size}`
+        );
 
         if (total.size > 0.0) {
           collector.recordVariable(
@@ -162,7 +170,10 @@ export function collectCoverageData(
       break;
     case "statement":
       {
-        collector.recordVariable(RuntimeVariable.COVERED_LINES, `${covered.size}`);
+        collector.recordVariable(
+          RuntimeVariable.COVERED_LINES,
+          `${covered.size}`
+        );
         collector.recordVariable(RuntimeVariable.TOTAL_LINES, `${total.size}`);
 
         if (total.size > 0.0) {
@@ -171,7 +182,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, '0');
+          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, "0");
         }
       }
       break;
@@ -181,7 +192,10 @@ export function collectCoverageData(
           RuntimeVariable.COVERED_FUNCTIONS,
           `${covered.size}`
         );
-        collector.recordVariable(RuntimeVariable.TOTAL_FUNCTIONS, `${total.size}`);
+        collector.recordVariable(
+          RuntimeVariable.TOTAL_FUNCTIONS,
+          `${total.size}`
+        );
 
         if (total.size > 0.0) {
           collector.recordVariable(
@@ -189,13 +203,16 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, '0');
+          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, "0");
         }
       }
       break;
     case "probe":
       {
-        collector.recordVariable(RuntimeVariable.COVERED_PROBES, `${covered.size}`);
+        collector.recordVariable(
+          RuntimeVariable.COVERED_PROBES,
+          `${covered.size}`
+        );
         collector.recordVariable(RuntimeVariable.TOTAL_PROBES, `${total.size}`);
 
         if (total.size > 0.0) {
@@ -204,7 +221,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, '0');
+          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, "0");
         }
       }
       break;
@@ -257,6 +274,6 @@ export function collectProbeCoverageData(
       `${covered.size / total}`
     );
   } else {
-    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, '0');
+    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, "0");
   }
 }

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -37,7 +37,7 @@ export function collectInitialVariables(
   currentSubject: SoliditySubject,
   targetPath: string
 ) {
-  collector.recordVariable(RuntimeVariable.VERSION, `${1}`);
+  collector.recordVariable(RuntimeVariable.VERSION, `1`);
   collector.recordVariable(
     RuntimeVariable.CONFIGURATION,
     Properties.configuration
@@ -156,7 +156,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.BRANCH_COVERAGE, `${0}`);
+          collector.recordVariable(RuntimeVariable.BRANCH_COVERAGE, `0`);
         }
       }
       break;
@@ -171,7 +171,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, `${0}`);
+          collector.recordVariable(RuntimeVariable.LINE_COVERAGE, '0');
         }
       }
       break;
@@ -189,7 +189,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, `${0}`);
+          collector.recordVariable(RuntimeVariable.FUNCTION_COVERAGE, '0');
         }
       }
       break;
@@ -204,7 +204,7 @@ export function collectCoverageData(
             `${covered.size / total.size}`
           );
         } else {
-          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, `${0}`);
+          collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, '0');
         }
       }
       break;
@@ -257,6 +257,6 @@ export function collectProbeCoverageData(
       `${covered.size / total}`
     );
   } else {
-    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, `${0}`);
+    collector.recordVariable(RuntimeVariable.PROBE_COVERAGE, '0');
   }
 }

--- a/src/util/fileSystem.ts
+++ b/src/util/fileSystem.ts
@@ -19,7 +19,7 @@
 import { existsSync, mkdirSync, rmdirSync, writeFileSync } from "fs";
 import * as path from "path";
 
-import { getUserInterface, Properties } from "@syntest/framework";
+import { getUserInterface, Properties } from "@syntest/core";
 const globby = require("globby");
 const recursive = require("recursive-readdir");
 const globalModules = require("global-modules");

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -1,4 +1,4 @@
-import { getUserInterface } from "@syntest/framework";
+import { getUserInterface } from "@syntest/core";
 
 const TruffleProvider = require("@truffle/provider");
 

--- a/test/testcase/AddressStatement.test.ts
+++ b/test/testcase/AddressStatement.test.ts
@@ -5,7 +5,7 @@ import {
   processConfig,
   setupLogger,
   setupOptions,
-} from "@syntest/framework";
+} from "@syntest/core";
 import { AddressStatement } from "../../src";
 
 const expect = chai.expect;

--- a/test/testcase/AddressStatement.test.ts
+++ b/test/testcase/AddressStatement.test.ts
@@ -13,7 +13,7 @@ const expect = chai.expect;
 describe("AddressStatement", () => {
   before(async () => {
     await guessCWD(null);
-    await setupOptions("", "");
+    await setupOptions("", []);
     await loadConfig();
     await processConfig({}, "");
     await setupLogger();

--- a/test/testcase/primitive/String.test.ts
+++ b/test/testcase/primitive/String.test.ts
@@ -6,8 +6,8 @@ import {
   setupLogger,
   setupOptions,
 } from "@syntest/core";
-import { StringStatement } from "../../../dist/testcase/statements/primitive/StringStatement";
-import { SoliditySampler } from "../../../dist/testcase/sampling/SoliditySampler";
+import { StringStatement } from "../../../src/testcase/statements/primitive/StringStatement";
+import { SoliditySampler } from "../../../src/testcase/sampling/SoliditySampler";
 
 const expect = chai.expect;
 

--- a/test/testcase/primitive/String.test.ts
+++ b/test/testcase/primitive/String.test.ts
@@ -6,7 +6,7 @@ import {
   TestCaseSampler,
   setupLogger,
   setupOptions,
-} from "@syntest/framework";
+} from "@syntest/core";
 import { StringStatement } from "../../../dist/testcase/statements/primitive/StringStatement";
 
 const expect = chai.expect;

--- a/test/testcase/primitive/String.test.ts
+++ b/test/testcase/primitive/String.test.ts
@@ -3,18 +3,18 @@ import {
   guessCWD,
   loadConfig,
   processConfig,
-  TestCaseSampler,
   setupLogger,
   setupOptions,
 } from "@syntest/core";
 import { StringStatement } from "../../../dist/testcase/statements/primitive/StringStatement";
+import { SoliditySampler } from "../../../dist/testcase/sampling/SoliditySampler";
 
 const expect = chai.expect;
 
 describe("StringStatement", () => {
   before(async () => {
     await guessCWD(null);
-    await setupOptions("", "");
+    await setupOptions("", []);
     await loadConfig();
     await processConfig({}, "");
     await setupLogger();
@@ -56,9 +56,9 @@ describe("StringStatement", () => {
   });
 
   it("Mutate gives exact other value", () => {
-    const mockedSampler = <TestCaseSampler>{};
+    const mockedSampler = <SoliditySampler>{};
     const statement = StringStatement.getRandom();
-    const mutation = statement.mutate(mockedSampler as TestCaseSampler, 0);
+    const mutation = statement.mutate(mockedSampler as SoliditySampler, 0);
 
     expect(statement.value != mutation.value);
   });


### PR DESCRIPTION
The core functionalities package of the SynTest-Framework is renamed from framework to core.
This should be updated in the code.
- [x] Change the package in package.json from @syntest/framework to @syntest/core
- [x] Change all references to @syntest/framework to @syntest/core
- [x] Fix breaking changes